### PR TITLE
fix(build): remove unnecessary Crossplane CRD application in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,8 +91,6 @@ dev: $(KIND) $(KUBECTL)
 	@$(INFO) Creating kind cluster
 	@$(KIND) create cluster --name=$(PROJECT_NAME)-dev
 	@$(KUBECTL) cluster-info --context kind-$(PROJECT_NAME)-dev
-	@$(INFO) Installing Crossplane CRDs
-	@$(KUBECTL) apply --server-side -k https://github.com/crossplane/crossplane//cluster?ref=master
 	@$(INFO) Installing Provider GitHub CRDs
 	@$(KUBECTL) apply -R -f package/crds
 	@$(INFO) Starting Provider GitHub controllers


### PR DESCRIPTION
### Description of your changes

Fixes the development environment setup by removing the broken and unnecessary application of core Crossplane CRDs. This change resolves initialization errors during local development. 
