### PR TITLE
(ci) upgrade deprecated CodeQL GitHub Actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,9 +39,9 @@ jobs:
           submodules: true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: go
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
### Description of your changes

CodeQL Action v2 is deprecated in favour of v3.
https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/