### PR TITLE
Add github access token caching mechanism, not to request token for every new api request

### DIFF
--- a/internal/clients/cached_client.go
+++ b/internal/clients/cached_client.go
@@ -32,7 +32,6 @@ import (
 // CachedClient represents a cached GitHub client with token reuse
 type CachedClient struct {
 	*Client
-	cacheKey string
 }
 
 // ClientCache manages cached GitHub clients to reduce token requests

--- a/internal/clients/cached_client.go
+++ b/internal/clients/cached_client.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2024 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clients
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/bradleyfalzon/ghinstallation/v2"
+	"github.com/google/go-github/v62/github"
+)
+
+// CachedClient represents a cached GitHub client with token reuse
+type CachedClient struct {
+	*Client
+	cacheKey string
+}
+
+// ClientCache manages cached GitHub clients to reduce token requests
+type ClientCache struct {
+	mu      sync.RWMutex
+	clients map[string]*cachedClientEntry
+}
+
+type cachedClientEntry struct {
+	client    *Client
+	createdAt time.Time
+	cacheKey  string
+}
+
+var (
+	globalClientCache = &ClientCache{
+		clients: make(map[string]*cachedClientEntry),
+	}
+	// Cache clients for 50 minutes (GitHub App tokens expire after 1 hour)
+	clientCacheTimeout = 50 * time.Minute
+)
+
+// generateCacheKey creates a consistent cache key from credentials
+func generateCacheKey(creds string) string {
+	hash := sha256.Sum256([]byte(creds))
+	return fmt.Sprintf("%x", hash[:8]) // Use first 8 bytes of hash
+}
+
+// NewCachedClient creates a new cached GitHub client that reuses tokens
+func NewCachedClient(creds string) (*Client, error) {
+	cacheKey := generateCacheKey(creds)
+
+	globalClientCache.mu.Lock()
+	defer globalClientCache.mu.Unlock()
+
+	// Check if we have a valid cached client
+	if entry, exists := globalClientCache.clients[cacheKey]; exists {
+		// Check if cache entry is still valid
+		if time.Since(entry.createdAt) < clientCacheTimeout {
+			return entry.client, nil
+		}
+		// Remove expired entry
+		delete(globalClientCache.clients, cacheKey)
+	}
+
+	// Create new client using existing logic
+	client, err := createNewClient(creds)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache the new client
+	globalClientCache.clients[cacheKey] = &cachedClientEntry{
+		client:    client,
+		createdAt: time.Now(),
+		cacheKey:  cacheKey,
+	}
+
+	return client, nil
+}
+
+// createNewClient contains the original client creation logic
+func createNewClient(creds string) (*Client, error) {
+	credss := strings.Split(creds, ",")
+	if len(credss) != 3 {
+		return nil, fmt.Errorf("invalid format for credentials")
+	}
+
+	appId, err := strconv.Atoi(credss[0])
+	if err != nil {
+		return nil, err
+	}
+
+	installationId, err := strconv.Atoi(credss[1])
+	if err != nil {
+		return nil, err
+	}
+
+	itr, err := ghinstallation.New(http.DefaultTransport, int64(appId), int64(installationId), []byte(credss[2]))
+	if err != nil {
+		return nil, err
+	}
+
+	ghclient := github.NewClient(&http.Client{Transport: itr})
+
+	return &Client{
+		Actions:       ghclient.Actions,
+		Dependabot:    ghclient.Dependabot,
+		Organizations: ghclient.Organizations,
+		Users:         ghclient.Users,
+		Teams:         ghclient.Teams,
+		Repositories:  ghclient.Repositories,
+	}, nil
+}
+
+// CleanupExpiredClients removes expired clients from cache (optional background cleanup)
+func CleanupExpiredClients() {
+	globalClientCache.mu.Lock()
+	defer globalClientCache.mu.Unlock()
+
+	now := time.Now()
+	for key, entry := range globalClientCache.clients {
+		if now.Sub(entry.createdAt) >= clientCacheTimeout {
+			delete(globalClientCache.clients, key)
+		}
+	}
+}

--- a/internal/controller/membership/membership.go
+++ b/internal/controller/membership/membership.go
@@ -65,7 +65,7 @@ func Setup(mgr ctrl.Manager, o controller.Options, metrics *telemetry.RateLimitM
 		managed.WithExternalConnecter(&connector{
 			kube:        mgr.GetClient(),
 			usage:       resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
-			newClientFn: ghclient.NewClient,
+			newClientFn: ghclient.NewCachedClient,
 			metrics:     metrics}),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithPollInterval(o.PollInterval),

--- a/internal/controller/organization/organization.go
+++ b/internal/controller/organization/organization.go
@@ -71,7 +71,7 @@ func Setup(mgr ctrl.Manager, o controller.Options, metrics *telemetry.RateLimitM
 		managed.WithExternalConnecter(&connector{
 			kube:        mgr.GetClient(),
 			usage:       resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
-			newClientFn: ghclient.NewClient,
+			newClientFn: ghclient.NewCachedClient,
 			metrics:     metrics}),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithPollInterval(o.PollInterval),

--- a/internal/controller/repository/repository.go
+++ b/internal/controller/repository/repository.go
@@ -78,7 +78,7 @@ func Setup(mgr ctrl.Manager, o controller.Options, metrics *telemetry.RateLimitM
 		managed.WithExternalConnecter(&connector{
 			kube:        mgr.GetClient(),
 			usage:       resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
-			newClientFn: ghclient.NewClient,
+			newClientFn: ghclient.NewCachedClient,
 			metrics:     metrics}),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithPollInterval(o.PollInterval),

--- a/internal/controller/team/team.go
+++ b/internal/controller/team/team.go
@@ -70,7 +70,7 @@ func Setup(mgr ctrl.Manager, o controller.Options, metrics *telemetry.RateLimitM
 		managed.WithExternalConnecter(&connector{
 			kube:        mgr.GetClient(),
 			usage:       resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
-			newClientFn: ghclient.NewClient,
+			newClientFn: ghclient.NewCachedClient,
 			metrics:     metrics}),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithPollInterval(o.PollInterval),


### PR DESCRIPTION
### Description of your changes
Right now we are calling github client for every request which is an issue regarding Github api rate limits, if you have too many managed resources there is quite big possibility you will hit limit which is max 12500 requests per hour for non Enterprise org and 15000 request for Enterprise one.This change will cache api token for specific time and all clients will use it in place of requesting new one every time


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
